### PR TITLE
Functional Model Support v2

### DIFF
--- a/talos/metrics/score_model.py
+++ b/talos/metrics/score_model.py
@@ -1,5 +1,5 @@
 from .performance import Performance
-from numpy import nan
+from numpy import nan, argmax
 
 
 def get_score(self):
@@ -14,7 +14,7 @@ def get_score(self):
     '''
 
     try:
-        y_pred = self.keras_model.predict_classes(self.x_val)
+        y_pred = argmax(self.keras_model.predict(self.x_val), axis=-1)
         return Performance(y_pred, self.y_val, self.shape, self.y_max).result
 
     except TypeError:


### PR DESCRIPTION
Substitute `model.predict_classes`  (only available for Sequential Model) using `numpy.argmax` with `axis=-1` to match predict_classes shape.

@mikkokotila the initial fix I proposed using `axis=1` only worked with classes output shape `(n,)` which is the case with a common Dense Layer.
<img width="564" alt="pred1" src="https://user-images.githubusercontent.com/23389282/43426376-c5e57bdc-9455-11e8-96e4-699b2105cc93.PNG">

So I tried to replicate your  `example (n, 1)` using a Reshape Layer, and indeed the fix was outputting something different than `predict_classes`.
__I changed `axis=-1` and it seems to match predict_classes shape for every case.__
<img width="948" alt="pred2" src="https://user-images.githubusercontent.com/23389282/43426569-5d329e52-9456-11e8-82e7-d177fae68682.PNG">

I'm pretty sure that this fix resolve the shape issue but if it's not the case send me your model for further testing.
