### PR TITLE
fix a missing SSL cert problem for quantum random number API call

### DIFF
--- a/talos/samplers/quantum/__init__.py
+++ b/talos/samplers/quantum/__init__.py
@@ -22,7 +22,7 @@ A Python interface to the ANU Quantum Random Numbers Server.
 
 http://qrng.anu.edu.au
 """
-
+import ssl
 import binascii
 import math
 import sys
@@ -85,7 +85,9 @@ if sys.version_info[0] == 2:
                 return default
 else:
     def get_json(url):
-        return json.loads(urlopen(url).read().decode('ascii'))
+        
+        context = ssl._create_unverified_context()
+        return json.loads(urlopen(url, context=context).read().decode('ascii'))
 
 
 def binary(array_length=100, block_size=100):


### PR DESCRIPTION
In the @daily-dev branch there is an SSL cert issue when the quantum random numbers are fetched from the source. This is affecting 2.7, 3.4 and 3.5. 

There might be some considerations with this. More about that [here](https://docs.python.org/2/library/ssl.html#verifying-certificates).

This is fixed with:

```
import ssl

# This restores the same behavior as before.
context = ssl._create_unverified_context()
urllib.urlopen(url, context=context)
```