### PR TITLE
Add ascending parameter to best_params.

### DIFF
--- a/talos/commands/reporting.py
+++ b/talos/commands/reporting.py
@@ -149,14 +149,14 @@ class Reporting:
 
         return out
 
-    def best_params(self, metric='val_acc', n=10):
+    def best_params(self, metric='val_acc', n=10, ascending=False):
 
         '''Get the best parameters of the experiment based on a metric.
         Returns a numpy array with the values in a format that can be used
         with the talos backend in Scan(). Adds an index as the last column.'''
 
         cols = self._cols(metric)
-        out = self.data[cols].sort_values(metric, ascending=False)
+        out = self.data[cols].sort_values(metric, ascending=ascending)
         out = out.drop(metric, axis=1).head(n)
         out.insert(out.shape[1], 'index_num', range(len(out)))
 


### PR DESCRIPTION
This allows flexiblity for parameters like val_mean_squared_error that should
be sorted in ascending order.

- make sure that all tests are passed 
- create some unit tests and update testing procedures accordingly 
- make PR to dev (or daily-dev)
