### PR TITLE
Return early stopper callback without wrapping

### DIFF
--- a/talos/examples/models.py
+++ b/talos/examples/models.py
@@ -40,7 +40,7 @@ def iris_model(x_train, y_train, x_val, y_val, params):
                     epochs=params['epochs'],
                     verbose=0,
                     validation_data=[x_val, y_val],
-                    callbacks=early_stopper(params['epochs'], mode=[1, 1]))
+                    callbacks=[early_stopper(params['epochs'], mode=[1, 1])])
 
     return out, model
 
@@ -73,8 +73,8 @@ def cervix_model(x_train, y_train, x_val, y_val, params):
                         epochs=params['epochs'],
                         verbose=0,
                         validation_data=[x_val, y_val],
-                        callbacks=early_stopper(params['epochs'],
+                        callbacks=[early_stopper(params['epochs'],
                                                 mode='moderate',
-                                                monitor='val_fmeasure'))
+                                                monitor='val_fmeasure')])
 
     return results, model

--- a/talos/model/early_stopper.py
+++ b/talos/model/early_stopper.py
@@ -34,4 +34,4 @@ def early_stopper(epochs,
                                 min_delta=mode[0],
                                 patience=mode[1],
                                 verbose=0, mode='auto')
-    return [_es_out]
+    return _es_out


### PR DESCRIPTION
All callbacks within Keras return as-is. By wrapping early_stopper, it
makes it incompatible with other callbacks a User might want to use.

Additionally updated the two examples in models.py.

- make sure that all tests are passed 
- create some unit tests and update testing procedures accordingly 
- make PR to dev (or daily-dev)
