### PR TITLE
Reporting: support metrics that are not hard-coded talos

### DIFF
--- a/talos/commands/reporting.py
+++ b/talos/commands/reporting.py
@@ -166,7 +166,7 @@ class Reporting:
         '''Helper to remove other than desired metric from data table'''
         if isinstance(metric, list) is False:
             metric = [metric]
-        cols_parameteres = set(self.data.columns) - set(metric_names()) # if it isn't a metric, it's a parameter
+        cols_parameters = set(self.data.columns) - set(metric_names()) # if it isn't a metric, it's a parameter
         cols = cols_parameters.union(set(metric)) # add back only the specified metrics
         cols = list(cols)
         return cols

--- a/talos/commands/reporting.py
+++ b/talos/commands/reporting.py
@@ -166,6 +166,7 @@ class Reporting:
         '''Helper to remove other than desired metric from data table'''
         if isinstance(metric, list) is False:
             metric = [metric]
-        cols = set(self.data.columns) - set(metric_names()) + set(metric)
+        cols_parameteres = set(self.data.columns) - set(metric_names()) # if it isn't a metric, it's a parameter
+        cols = cols_parameters.union(set(metric)) # add back only the specified metrics
         cols = list(cols)
         return cols

--- a/talos/commands/reporting.py
+++ b/talos/commands/reporting.py
@@ -166,6 +166,6 @@ class Reporting:
         '''Helper to remove other than desired metric from data table'''
         if isinstance(metric, list) is False:
             metric = [metric]
-        cols = set(self.data.columns) - set(metric_names) + set(metric)
+        cols = set(self.data.columns) - set(metric_names()) + set(metric)
         cols = list(cols)
         return cols

--- a/talos/commands/reporting.py
+++ b/talos/commands/reporting.py
@@ -49,10 +49,15 @@ class Reporting:
 
         '''Returns a correlation table against a given metric. Drops
         all other metrics and correlates against hyperparameters only.'''
-
+        
+        def _to_numeric(tbl):
+            '''Helper to convert all columns to numeric in a table'''
+            new_columns = {col_name: to_numeric(tbl[col_name], errors='ignore') for col_name in tbl.columns}
+            return DataFrame(new_columns)
+        
         cols = self._cols(metric)
         tbl = self.data[cols]
-        tbl = self._to_numeric(tbl)
+        tbl = _to_numeric(tbl)
         out = tbl.corr()[metric]
 
         return out[out != 1]
@@ -161,11 +166,6 @@ class Reporting:
         out.insert(out.shape[1], 'index_num', range(len(out)))
 
         return out.values
-    
-    def _to_numeric(self, tbl):
-        '''Helper to convert all columns to numeric in a table'''
-        new_columns = {col_name: to_numeric(tbl[col_name], errors='ignore') for col_name in tbl.columns}
-        return DataFrame(new_columns)
         
     
     def _cols(self, metric):

--- a/talos/commands/reporting.py
+++ b/talos/commands/reporting.py
@@ -50,9 +50,8 @@ class Reporting:
         '''Returns a correlation table against a given metric. Drops
         all other metrics and correlates against hyperparameters only.'''
 
-        columns = self._cols(metric)
-        out = self.data[columns]
-        out.insert(0, metric, self.data[metric])
+        cols = self._cols(metric)
+        out = self.data[cols]
         out = out.corr()[metric]
 
         return out[out != 1]
@@ -167,6 +166,6 @@ class Reporting:
         '''Helper to remove other than desired metric from data table'''
         if isinstance(metric, list) is False:
             metric = [metric]
-        cols = (set(cols) - set(metric_names)) + set(metric)
+        cols = set(self.data.columns) - set(metric_names) + set(metric)
         cols = list(cols)
         return cols

--- a/talos/commands/reporting.py
+++ b/talos/commands/reporting.py
@@ -1,4 +1,4 @@
-from pandas import read_csv
+from pandas import read_csv, to_numeric, DataFrame
 from astetik import line, hist, corr, regs, bargrid, kde
 from ..metrics.names import metric_names
 
@@ -51,8 +51,9 @@ class Reporting:
         all other metrics and correlates against hyperparameters only.'''
 
         cols = self._cols(metric)
-        out = self.data[cols]
-        out = out.corr()[metric]
+        tbl = self.data[cols]
+        tbl = self._to_numeric(tbl)
+        out = tbl.corr()[metric]
 
         return out[out != 1]
 
@@ -160,9 +161,14 @@ class Reporting:
         out.insert(out.shape[1], 'index_num', range(len(out)))
 
         return out.values
-
+    
+    def _to_numeric(self, tbl):
+        '''Helper to convert all columns to numeric in a table'''
+        new_columns = {col_name: to_numeric(tbl[col_name], errors='ignore') for col_name in tbl.columns}
+        return DataFrame(new_columns)
+        
+    
     def _cols(self, metric):
-
         '''Helper to remove other than desired metric from data table'''
         if isinstance(metric, list) is False:
             metric = [metric]

--- a/talos/commands/reporting.py
+++ b/talos/commands/reporting.py
@@ -50,7 +50,7 @@ class Reporting:
         '''Returns a correlation table against a given metric. Drops
         all other metrics and correlates against hyperparameters only.'''
 
-        columns = [c for c in self.data.columns if c not in metric_names()]
+        columns = self._cols(metric)
         out = self.data[columns]
         out.insert(0, metric, self.data[metric])
         out = out.corr()[metric]
@@ -165,15 +165,8 @@ class Reporting:
     def _cols(self, metric):
 
         '''Helper to remove other than desired metric from data table'''
-
-        cols = [col for col in self.data.columns if col not in metric_names()]
-
         if isinstance(metric, list) is False:
             metric = [metric]
-        for i, metric in enumerate(metric):
-            cols.insert(i, metric)
-
-        # make sure only unique values in col list
-        cols = list(set(cols))
-
+        cols = (set(cols) - set(metric_names)) + set(metric)
+        cols = list(cols)
         return cols


### PR DESCRIPTION
This pull request [partially] resolves #136.

A more permanent solution requires changing the Reporting api so that the user may provide a set of metrics to be used throughout the report.



1. [x] make sure that all tests are passed
2. [x] create some unit tests and update testing procedures accordingly 
   Here is the same test run with the original
   https://gist.github.com/renxida/9e53e1307abd44b33e0984e1ec49937c
   Here is a test, run with my modified version of reporting.py
   https://gist.github.com/fba8417e04b1c9094bf924db0a2938ec