### PR TITLE
Dev

### DIFF
--- a/talos/commands/reporting.py
+++ b/talos/commands/reporting.py
@@ -2,7 +2,7 @@ from pandas import read_csv
 from ..utils.connection_check import is_connected
 
 if is_connected() is True:
-    from astetik import line, hist, corr, regs, bargrid, kde
+    from astetik import line, hist, corr, regs, bargrid, kde, box
 
 from ..metrics.names import metric_names
 
@@ -108,6 +108,17 @@ class Reporting:
         '''
 
         return regs(self.data, x, y)
+
+    def plot_box(self, x, y='val_acc', hue=None):
+
+        '''A box plot with data on two axis
+
+        x = data for the x axis
+        y = data for the y axis
+        hue = data for the hue separation
+        '''
+
+        return box(self.data, x, y, hue)
 
     def plot_bars(self, x, y, hue, col):
 


### PR DESCRIPTION
Added a plot_box method to Reporting, which takes x and y, and optional hue as parameters.
It works as a 'lighter' version of plot_bars, where you can look at a single parameter rather than 4.

Haven't added it to the unit tests since, like plot_bars, it has no default parameters (and I didn't see a unit test for plot_bars to make the equivalent), but I've tested it on Google colab with success.