### PR TITLE
Add ability to filter out unwanted premutations

### DIFF
--- a/talos/parameters/ParamGrid.py
+++ b/talos/parameters/ParamGrid.py
@@ -3,6 +3,7 @@ import numpy as np
 from ..reducers.sample_reducer import sample_reducer
 from .round_params import create_params_dict
 
+
 class ParamGrid:
 
     '''Suite for handling parameters internally within Talos
@@ -22,7 +23,6 @@ class ParamGrid:
         for i, col in enumerate(self.main_self.params.keys()):
             self.param_reference[col] = i
 
-
         # convert the input to useful format
         self._p = self._param_input_conversion()
 
@@ -30,9 +30,9 @@ class ParamGrid:
         ls = [list(self._p[key]) for key in self._p.keys()]
 
         # get the number of total dimensions / permutations
-        virtual_grid_size=1
+        virtual_grid_size = 1
         for l in ls:
-            virtual_grid_size*=len(l)
+            virtual_grid_size *= len(l)
         final_grid_size = virtual_grid_size
 
         # calculate the size of the downsample
@@ -43,21 +43,22 @@ class ParamGrid:
         if self.main_self.round_limit is not None:
             final_grid_size = min(final_grid_size, self.main_self.round_limit)
 
-        self.param_grid=self._create_param_grid(ls,final_grid_size,virtual_grid_size)
+        self.param_grid = self._create_param_grid(ls, final_grid_size, virtual_grid_size)
 
-        fn=lambda i:self.main_self.premutation_filter(create_params_dict(self,i))
-        if self.main_self.premutation_filter != None:
-            grid_indices=list(filter(fn,range(len(self.param_grid))))
-            self.param_grid=self.param_grid[grid_indices]
-            final_expanded_grid_size=final_grid_size
-            while len(self.param_grid)<final_grid_size and final_expanded_grid_size<virtual_grid_size:
-                final_expanded_grid_size*=2
-                if final_expanded_grid_size>virtual_grid_size:
-                    final_expanded_grid_size=virtual_grid_size
-                self.param_grid=self._create_param_grid(ls,final_expanded_grid_size,virtual_grid_size)
-                grid_indices=list(filter(fn,range(len(self.param_grid))))
-                self.param_grid=self.param_grid[grid_indices]
-            self.param_grid=self.param_grid[:final_grid_size]
+        def fn(i):
+            return self.main_self.premutation_filter(create_params_dict(self, i))
+        if self.main_self.premutation_filter is not None:
+            grid_indices = list(filter(fn, range(len(self.param_grid))))
+            self.param_grid = self.param_grid[grid_indices]
+            final_expanded_grid_size = final_grid_size
+            while len(self.param_grid) < final_grid_size and final_expanded_grid_size < virtual_grid_size:
+                final_expanded_grid_size *= 2
+                if final_expanded_grid_size > virtual_grid_size:
+                    final_expanded_grid_size = virtual_grid_size
+                self.param_grid = self._create_param_grid(ls, final_expanded_grid_size, virtual_grid_size)
+                grid_indices=list(filter(fn, range(len(self.param_grid))))
+                self.param_grid = self.param_grid[grid_indices]
+            self.param_grid = self.param_grid[:final_grid_size]
 
         # initialize with random shuffle if needed
         if self.main_self.shuffle:
@@ -69,7 +70,7 @@ class ParamGrid:
         # add the log index to param grid
         self.param_grid = np.column_stack((self.param_grid, self.param_log))
 
-    def _create_param_grid(self,ls,final_grid_size,virtual_grid_size):
+    def _create_param_grid(self, ls, final_grid_size, virtual_grid_size):
         # select premutations according to downsample
         if final_grid_size < virtual_grid_size:
             out = sample_reducer(self, final_grid_size, virtual_grid_size)

--- a/talos/parameters/ParamGrid.py
+++ b/talos/parameters/ParamGrid.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from ..reducers.sample_reducer import sample_reducer
-
+from .round_params import create_params_dict
 
 class ParamGrid:
 
@@ -44,6 +44,20 @@ class ParamGrid:
             final_grid_size = min(final_grid_size, self.main_self.round_limit)
 
         self.param_grid=self._create_param_grid(ls,final_grid_size,virtual_grid_size)
+
+        fn=lambda i:self.main_self.premutation_filter(create_params_dict(self,i))
+        if self.main_self.premutation_filter != None:
+            grid_indices=list(filter(fn,range(len(self.param_grid))))
+            self.param_grid=self.param_grid[grid_indices]
+            final_expanded_grid_size=final_grid_size
+            while len(self.param_grid)<final_grid_size and final_expanded_grid_size<virtual_grid_size:
+                final_expanded_grid_size*=2
+                if final_expanded_grid_size>virtual_grid_size:
+                    final_expanded_grid_size=virtual_grid_size
+                self.param_grid=self._create_param_grid(ls,final_expanded_grid_size,virtual_grid_size)
+                grid_indices=list(filter(fn,range(len(self.param_grid))))
+                self.param_grid=self.param_grid[grid_indices]
+            self.param_grid=self.param_grid[:final_grid_size]
 
         # initialize with random shuffle if needed
         if self.main_self.shuffle:

--- a/talos/parameters/ParamGrid.py
+++ b/talos/parameters/ParamGrid.py
@@ -43,14 +43,7 @@ class ParamGrid:
         if self.main_self.round_limit is not None:
             final_grid_size = min(final_grid_size, self.main_self.round_limit)
 
-        # select premutations according to downsample
-        if final_grid_size < virtual_grid_size:
-            out = sample_reducer(self, final_grid_size, virtual_grid_size)
-        else:
-            out = range(0, final_grid_size)
-
-        # build the parameter permutation grid
-        self.param_grid = self._create_param_permutations(ls, out)
+        self.param_grid=self._create_param_grid(ls,final_grid_size,virtual_grid_size)
 
         # initialize with random shuffle if needed
         if self.main_self.shuffle:
@@ -61,6 +54,17 @@ class ParamGrid:
 
         # add the log index to param grid
         self.param_grid = np.column_stack((self.param_grid, self.param_log))
+
+    def _create_param_grid(self,ls,final_grid_size,virtual_grid_size):
+        # select premutations according to downsample
+        if final_grid_size < virtual_grid_size:
+            out = sample_reducer(self, final_grid_size, virtual_grid_size)
+        else:
+            out = range(0, final_grid_size)
+
+        # build the parameter permutation grid
+        param_grid = self._create_param_permutations(ls, out)
+        return param_grid
 
     def _create_param_permutations(self, ls, permutation_index):
 

--- a/talos/parameters/ParamGrid.py
+++ b/talos/parameters/ParamGrid.py
@@ -17,6 +17,12 @@ class ParamGrid:
 
         self.main_self = main_self
 
+        # creates a reference dictionary for column number to label
+        self.param_reference = {}
+        for i, col in enumerate(self.main_self.params.keys()):
+            self.param_reference[col] = i
+
+
         # convert the input to useful format
         self._p = self._param_input_conversion()
 

--- a/talos/parameters/round_params.py
+++ b/talos/parameters/round_params.py
@@ -1,5 +1,13 @@
 from numpy import random
 
+def create_params_dict(self,_choice):
+    _round_params_dict = {}
+    x = 0
+    for key in self.param_reference.keys():
+        _round_params_dict[key] = self.param_grid[_choice][x]
+        x += 1
+
+    return _round_params_dict
 
 def round_params(self):
 
@@ -20,10 +28,5 @@ def round_params(self):
     self.param_log.remove(_choice)
 
     # create a dictionary for the current round
-    _round_params_dict = {}
-    x = 0
-    for key in self.param_reference.keys():
-        _round_params_dict[key] = self.param_grid[_choice][x]
-        x += 1
+    return create_params_dict(self,_choice)
 
-    return _round_params_dict

--- a/talos/parameters/round_params.py
+++ b/talos/parameters/round_params.py
@@ -1,6 +1,7 @@
 from numpy import random
 
-def create_params_dict(self,_choice):
+
+def create_params_dict(self, _choice):
     _round_params_dict = {}
     x = 0
     for key in self.param_reference.keys():
@@ -8,6 +9,7 @@ def create_params_dict(self,_choice):
         x += 1
 
     return _round_params_dict
+
 
 def round_params(self):
 
@@ -28,5 +30,4 @@ def round_params(self):
     self.param_log.remove(_choice)
 
     # create a dictionary for the current round
-    return create_params_dict(self,_choice)
-
+    return create_params_dict(self, _choice)

--- a/talos/scan/Scan.py
+++ b/talos/scan/Scan.py
@@ -155,8 +155,8 @@ class Scan:
         self.shuffle = shuffle
         self.random_method = random_method
         self.search_method = search_method
-        self.max_iteration_start_time=max_iteration_start_time
-        self.premutation_filter=premutation_filter
+        self.max_iteration_start_time = max_iteration_start_time
+        self.premutation_filter = premutation_filter
         self.reduction_method = reduction_method
         self.reduction_interval = reduction_interval
         self.reduction_window = reduction_window

--- a/talos/scan/Scan.py
+++ b/talos/scan/Scan.py
@@ -126,6 +126,7 @@ class Scan:
                  seed=None,
                  search_method='random',
                  max_iteration_start_time=None,
+                 premutation_filter=None,
                  reduction_method=None,
                  reduction_interval=50,
                  reduction_window=20,
@@ -155,6 +156,7 @@ class Scan:
         self.random_method = random_method
         self.search_method = search_method
         self.max_iteration_start_time=max_iteration_start_time
+        self.premutation_filter=premutation_filter
         self.reduction_method = reduction_method
         self.reduction_interval = reduction_interval
         self.reduction_window = reduction_window

--- a/talos/scan/scan_prepare.py
+++ b/talos/scan/scan_prepare.py
@@ -43,12 +43,8 @@ def scan_prepare(self):
     self.paramgrid_object = ParamGrid(self)
     self.param_log = self.paramgrid_object.param_log
     self.param_grid = self.paramgrid_object.param_grid
+    self.param_reference = self.paramgrid_object.param_reference
     del self.paramgrid_object
-
-    # creates a reference dictionary for column number to label
-    self.param_reference = {}
-    for i, col in enumerate(self.params.keys()):
-        self.param_reference[col] = i
 
     self.round_counter = 0
     self.peak_epochs = []

--- a/test/core_tests/test_scan.py
+++ b/test/core_tests/test_scan.py
@@ -77,6 +77,13 @@ class TestIris:
              experiment_no='000', model=ta.templates.models.iris,
              last_epoch_value=True)
 
+    def test_scan_iris_3(self):
+        print("Running Iris dataset test 2...")
+        Scan(self.x, self.y, params=p3, dataset_name='testing',
+             experiment_no='000', model=ta.templates.models.iris,
+             premutation_filter=lambda p: p['first_neuron']*p['hidden_layers']<150,
+             last_epoch_value=True)
+
     def test_scan_iris_explicit_validation_set(self):
         print("Running explicit validation dataset test with metric reduction")
         Scan(self.x_train, self.y_train, params=p2,

--- a/test/core_tests/test_scan.py
+++ b/test/core_tests/test_scan.py
@@ -59,10 +59,10 @@ p3 = {'lr': (0.5, 5, 10),
       'last_activation': [sigmoid]}
 
 p4 = {'lr': [1],
-      'first_neuron': [8, 64],
-      'hidden_layers': [2, 5],
-      'batch_size': [30],
-      'epochs': [3],
+      'first_neuron': [8, 24, 64],
+      'hidden_layers': [2, 5, 10],
+      'batch_size': [15, 30],
+      'epochs': [1],
       'dropout': [0],
       'weight_regulizer': [None],
       'shapes': ['funnel'],
@@ -96,7 +96,7 @@ class TestIris:
         Scan(self.x, self.y, params=p4, dataset_name='testing',
              experiment_no='000', model=ta.templates.models.iris,
              premutation_filter=lambda p: p['first_neuron']*p['hidden_layers']<150,
-             round_limit=1,
+             round_limit=4,
              last_epoch_value=True)
 
     def test_scan_iris_explicit_validation_set(self):

--- a/test/core_tests/test_scan.py
+++ b/test/core_tests/test_scan.py
@@ -59,8 +59,8 @@ p3 = {'lr': (0.5, 5, 10),
       'last_activation': [sigmoid]}
 
 p4 = {'lr': [1],
-      'first_neuron': [8, 32, 64],
-      'hidden_layers': [2, 4, 5],
+      'first_neuron': [8, 64],
+      'hidden_layers': [2, 5],
       'batch_size': [30],
       'epochs': [3],
       'dropout': [0],
@@ -92,8 +92,8 @@ class TestIris:
              last_epoch_value=True)
 
     def test_scan_iris_3(self):
-        print("Running Iris dataset test 2...")
-        Scan(self.x, self.y, params=p3, dataset_name='testing',
+        print("Running Iris dataset test 3...")
+        Scan(self.x, self.y, params=p4, dataset_name='testing',
              experiment_no='000', model=ta.templates.models.iris,
              premutation_filter=lambda p: p['first_neuron']*p['hidden_layers']<150,
              last_epoch_value=True)

--- a/test/core_tests/test_scan.py
+++ b/test/core_tests/test_scan.py
@@ -58,6 +58,20 @@ p3 = {'lr': (0.5, 5, 10),
       'activation': [relu],
       'last_activation': [sigmoid]}
 
+p4 = {'lr': [1],
+      'first_neuron': [8, 32, 64],
+      'hidden_layers': [2, 4, 5],
+      'batch_size': [30],
+      'epochs': [3],
+      'dropout': [0],
+      'weight_regulizer': [None],
+      'shapes': ['funnel'],
+      'emb_output_dims': [None],
+      'optimizer': [Nadam],
+      'losses': [softmax],
+      'activation': [relu],
+      'last_activation': [sigmoid]}
+
 
 class TestIris:
 

--- a/test/core_tests/test_scan.py
+++ b/test/core_tests/test_scan.py
@@ -68,7 +68,7 @@ p4 = {'lr': [1],
       'shapes': ['funnel'],
       'emb_output_dims': [None],
       'optimizer': [Nadam],
-      'losses': [softmax],
+      'losses': [categorical_crossentropy],
       'activation': [relu],
       'last_activation': [sigmoid]}
 
@@ -96,6 +96,7 @@ class TestIris:
         Scan(self.x, self.y, params=p4, dataset_name='testing',
              experiment_no='000', model=ta.templates.models.iris,
              premutation_filter=lambda p: p['first_neuron']*p['hidden_layers']<150,
+             round_limit=1,
              last_epoch_value=True)
 
     def test_scan_iris_explicit_validation_set(self):

--- a/test_script.py
+++ b/test_script.py
@@ -52,5 +52,6 @@ if __name__ == '__main__':
     TestIris().test_scan_iris_explicit_validation_set_force_fail()
     TestIris().test_scan_iris_1()
     TestIris().test_scan_iris_2()
+    TestIris().test_scan_iris_3()
     TestReporting()
     TestLoadDatasets()


### PR DESCRIPTION
I propose to fix https://github.com/autonomio/talos/issues/223 by this pull request

The code is used like

    talos.Scan(
        ...
        ,premutation_filter=lambda p: p['hidden_layers']<3 or p['first_neuron']<10)

I have tested locally but not added any tests