### PR TITLE
Added stopping after wall clock time

### DIFF
--- a/talos/scan/Scan.py
+++ b/talos/scan/Scan.py
@@ -124,6 +124,7 @@ class Scan:
                  random_method='uniform_mersenne',
                  seed=None,
                  search_method='random',
+                 max_iteration_start_time=None,
                  reduction_method=None,
                  reduction_interval=50,
                  reduction_window=20,
@@ -151,6 +152,7 @@ class Scan:
         self.shuffle = shuffle
         self.random_method = random_method
         self.search_method = search_method
+        self.max_iteration_start_time=max_iteration_start_time
         self.reduction_method = reduction_method
         self.reduction_interval = reduction_interval
         self.reduction_window = reduction_window

--- a/talos/scan/scan_run.py
+++ b/talos/scan/scan_run.py
@@ -1,5 +1,7 @@
 from tqdm import tqdm
 
+from datetime import datetime
+
 from ..utils.results import result_todf, peak_epochs_todf
 from .scan_round import scan_round
 from .scan_finish import scan_finish
@@ -9,6 +11,9 @@ def scan_run(self):
 
     '''The high-level management of the scan procedures
     onwards from preparation. Manages round_run()'''
+    
+    if self.max_iteration_start_time != None:
+        stoptime=datetime.strptime(self.max_iteration_start_time,"%Y-%m-%d %H:%M")
 
     # main loop for the experiment
     # NOTE: the progress bar is also updated on line 73
@@ -17,6 +22,9 @@ def scan_run(self):
     while len(self.param_log) != 0:
         self = scan_round(self)
         self.pbar.update(1)
+        if self.max_iteration_start_time != None and datetime.now() > stoptime:
+            print("Time limit reached, experiment finished")
+            break
     self.pbar.close()
 
     # save the results


### PR DESCRIPTION
Suggestion for how to add stopping after wall clock time as per https://github.com/autonomio/talos/issues/225

usage, pass `max_iteration_start_time='YYYY-MM-DD HH:mm'` to Scan