### PR TITLE
Define entropy as nan by default

### DIFF
--- a/talos/metrics/entropy.py
+++ b/talos/metrics/entropy.py
@@ -21,34 +21,24 @@ def epoch_entropy(history):
 
     keys = list(history.history.keys())
     no_of_items = len(keys)
+    acc_entropy, loss_entropy = nan, nan
 
     if no_of_items == 1:
         if 'loss' in keys:
             loss_entropy = entropy(history.history['loss'])
-            acc_entropy = nan
-        else:
-            loss_entropy = nan
-            acc_entropy = nan
 
     elif no_of_items == 2:
         if 'acc' in keys and 'loss' in keys:
             loss_entropy = entropy(history.history['loss'])
             acc_entropy = entropy(history.history['acc'])
-        else:
-            loss_entropy = nan
-            acc_entropy = nan
 
     elif no_of_items >= 4:
         if 'acc' in keys:
             acc_entropy = entropy(history.history['val_acc'],
                                   history.history['acc'])
-        else:
-            acc_entropy = nan
 
         if 'loss' in keys:
             loss_entropy = entropy(history.history['val_loss'],
                                    history.history['loss'])
-        else:
-            loss_entropy = nan
 
     return [acc_entropy, loss_entropy]

--- a/talos/metrics/entropy.py
+++ b/talos/metrics/entropy.py
@@ -18,10 +18,10 @@ def epoch_entropy(history):
     # TODO Right now this does not handle all cases well and needs
       to be thought about properly.
     '''
+    acc_entropy, loss_entropy = nan, nan
 
     keys = list(history.history.keys())
     no_of_items = len(keys)
-    acc_entropy, loss_entropy = nan, nan
 
     if no_of_items == 1:
         if 'loss' in keys:
@@ -33,11 +33,11 @@ def epoch_entropy(history):
             acc_entropy = entropy(history.history['acc'])
 
     elif no_of_items >= 4:
-        if 'acc' in keys:
+        if 'acc' in keys and 'val_acc' in keys:
             acc_entropy = entropy(history.history['val_acc'],
                                   history.history['acc'])
 
-        if 'loss' in keys:
+        if 'loss' in keys and 'val_loss' in keys:
             loss_entropy = entropy(history.history['val_loss'],
                                    history.history['loss'])
 


### PR DESCRIPTION
The case `no_of_items == 3` is not fetched by the current approach, but
it can happen that users have defined their own metrics inside the history
object where this case can happen. Then, this code throws `local variable
'acc_entropy' referenced before assignment`. Furthermore, defining the
entropy values in the beginning gives also cleaner code.

Signed-off-by: Timo Korthals <tkorthals@cit-ec.uni-bielefeld.de>