### PR TITLE
Lock package versions for deps to legacy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,10 +24,12 @@ try:
 except ImportError:
     from distutils.core import setup
 
-install_requires = ['wrangle',
+install_requires = ['statsmodels>=0.11.0',
+                    'wrangle',
                     'numpy',
                     'pandas',
-                    'keras',
+                    'tensorflow<=1.5.0',
+                    'keras==2.3.0',
                     'astetik',
                     'sklearn',
                     'tqdm',


### PR DESCRIPTION
As it stands, the inevitable move is to support Tensorflow and Pytorch, and as multi-backend Keras no longer has support in April, likewise, Talos will not support it. The `~0.6` version of Talos will be the last to support multi-backend Keras. Talos 1.0 will support Tensorflow (and tf.keras of course) and Pytorch.