### PR TITLE
Added docs for task argument in evaluate()

### DIFF
--- a/docs/Evaluate.md
+++ b/docs/Evaluate.md
@@ -24,6 +24,7 @@ Parameter | Default | Description
 --------- | ------- | -----------
 `x` | NA | the predictor data x
 `y` | NA | the prediction data y (truth)
+`task`| NA | One of the following strings: 'binary', 'multi_class', 'multi_label', or 'continuous'.
 `model_id` | None | the model_id to be used
 `folds` | None | number of folds to be used for cross-validation
 `shuffle` | None | if data is shuffled before splitting


### PR DESCRIPTION
Adding undocumented but required `task` argument in Evaluate.evaluate() to docs.

## You want to make a PR to Talos

Thanks so much :) First, please take a moment to carefully check through
the below items:

#### Sanity

- [X] I'm aware of the implications of the proposed changes
- [X] Code is [PEP8](https://www.python.org/dev/peps/pep-0008/)
- [X] I'm making the PR to `master`

#### Docs

- [X] [Docs](https://autonomio.github.io/talos) are updated -> just trying to fix that