### PR TITLE
Adding sample_weight to talos.Scan()

### DIFF
--- a/docs/Scan.md
+++ b/docs/Scan.md
@@ -22,6 +22,7 @@ Argument | Input | Description
 `experiment_name` | str | Used for creating the experiment logging folder
 `x_val` | array or list of arrays | validation data for x
 `y_val` | array or list of arrays | validation data for y
+`sample_weight` | array or list of arrays | Weights for each example in the data see [Keras fit method](https://keras.io/api/models/model_training_apis/#fit-method)
 `val_split` | float | validation data split ratio
 `random_method` | str | the random method to be used
 `seed` | float | Seed for random states
@@ -50,6 +51,19 @@ talos.Scan(...
           )
 ```
 
+NOTE: `model` must have the following signature:
+
+```python
+
+def my_model(x_train, y_train, x_val, y_val, params, *kwargs):
+```
+
+Unless `sample_weight` is passed in which case it must have:
+
+```python
+
+def my_model(x_train, y_train, x_val, y_val, params, sample_weight, *kwargs):
+```
 
 
 ## Scan Object Properties

--- a/talos/model/ingest_model.py
+++ b/talos/model/ingest_model.py
@@ -10,9 +10,9 @@ def ingest_model(self):
                           self.y_val,
                           self.round_params,
                           self.sample_weight_train)
-    else:
-        return self.model(self.x_train,
-                          self.y_train,
-                          self.x_val,
-                          self.y_val,
-                          self.round_params)
+
+    return self.model(self.x_train,
+                      self.y_train,
+                      self.x_val,
+                      self.y_val,
+                      self.round_params)

--- a/talos/model/ingest_model.py
+++ b/talos/model/ingest_model.py
@@ -3,8 +3,16 @@ def ingest_model(self):
     '''Ingests the model that is input by the user
     through Scan() model paramater.'''
 
-    return self.model(self.x_train,
-                      self.y_train,
-                      self.x_val,
-                      self.y_val,
-                      self.round_params)
+    if self.sample_weight_train is not None:
+        return self.model(self.x_train,
+                          self.y_train,
+                          self.x_val,
+                          self.y_val,
+                          self.round_params,
+                          self.sample_weight_train)
+    else:
+        return self.model(self.x_train,
+                          self.y_train,
+                          self.x_val,
+                          self.y_val,
+                          self.round_params)

--- a/talos/scan/Scan.py
+++ b/talos/scan/Scan.py
@@ -135,6 +135,7 @@ class Scan:
                  experiment_name,
                  x_val=None,
                  y_val=None,
+                 sample_weight=None,
                  val_split=.3,
                  random_method='uniform_mersenne',
                  seed=None,
@@ -156,11 +157,12 @@ class Scan:
 
         self.x = x
         self.y = y
-        self.params = params
+        self.params = parasm
         self.model = model
         self.experiment_name = experiment_name
         self.x_val = x_val
         self.y_val = y_val
+        self.sample_weight = sample_weight
         self.val_split = val_split
 
         # randomness

--- a/talos/scan/Scan.py
+++ b/talos/scan/Scan.py
@@ -157,7 +157,7 @@ class Scan:
 
         self.x = x
         self.y = y
-        self.params = parasm
+        self.params = params
         self.model = model
         self.experiment_name = experiment_name
         self.x_val = x_val

--- a/talos/utils/validation_split.py
+++ b/talos/utils/validation_split.py
@@ -22,6 +22,10 @@ def validation_split(self):
         self.x_val = self.x[limit:]
         self.y_val = self.y[limit:]
 
+        if self.sample_weight is not None:
+            self.sample_weight_train = self.sample_weight[:limit]
+            self.sample_weight_val = self.sample_weight[limit:]
+
     return self
 
 
@@ -62,6 +66,8 @@ def random_shuffle(self):
         self.x = self.x[ix]
 
     self.y = self.y[ix]
+    if self.sample_weight is not None:
+        self.sample_weight = self.sample_weight[ix]
 
 
 def kfold(x, y, folds=10, shuffled=True):

--- a/test/commands/test_scan.py
+++ b/test/commands/test_scan.py
@@ -20,7 +20,13 @@ def test_scan(test_sample_weights=False):
          'dropout': (.05, .35, .1),
          'epochs': [50]}
 
-    def iris_model(x_train, y_train, x_val, y_val, params, sample_weights=None):
+    def iris_model(x_train,
+                   y_train,
+                   x_val,
+                   y_val,
+                   params,
+                   sample_weights=None
+                  ):
 
         model = Sequential()
         model.add(Dense(params['first_neuron'],
@@ -51,7 +57,6 @@ def test_scan(test_sample_weights=False):
 
     x, y = talos.templates.datasets.iris()
 
-
     if not test_sample_weights:
         scan_object = talos.Scan(x=x,
                                  y=y,
@@ -68,7 +73,7 @@ def test_scan(test_sample_weights=False):
                                  reduction_metric='val_acc',
                                  minimize_loss=False,
                                  boolean_limit=lambda p: p['first_neuron'] * p['hidden_layers'] < 220
-        )
+                                )
     else:
         scan_object = talos.Scan(x=x,
                                  y=y,
@@ -86,7 +91,7 @@ def test_scan(test_sample_weights=False):
                                  reduction_metric='val_acc',
                                  minimize_loss=False,
                                  boolean_limit=lambda p: p['first_neuron'] * p['hidden_layers'] < 220
-        )
+                                )
 
     x = x[:50]
     y = y[:50]

--- a/test/commands/test_scan.py
+++ b/test/commands/test_scan.py
@@ -1,4 +1,4 @@
-def test_scan():
+def test_scan(test_sample_weights=False):
 
     print("\n >>> start Scan()...")
 
@@ -9,6 +9,7 @@ def test_scan():
     from keras.activations import relu, elu
     from keras.layers import Dense
     from keras.models import Sequential
+    from numpy.random import rand
 
     p = {'activation': [relu, elu],
          'optimizer': ['Nadam', Adam],
@@ -19,7 +20,7 @@ def test_scan():
          'dropout': (.05, .35, .1),
          'epochs': [50]}
 
-    def iris_model(x_train, y_train, x_val, y_val, params):
+    def iris_model(x_train, y_train, x_val, y_val, params, sample_weights=None):
 
         model = Sequential()
         model.add(Dense(params['first_neuron'],
@@ -42,6 +43,7 @@ def test_scan():
         out = model.fit(x_train, y_train,
                         batch_size=25,
                         epochs=params['epochs'],
+                        sample_weights=sample_weights,
                         validation_data=[x_val, y_val],
                         verbose=0)
 
@@ -49,22 +51,42 @@ def test_scan():
 
     x, y = talos.templates.datasets.iris()
 
-    scan_object = talos.Scan(x=x,
-                             y=y,
-                             params=p,
-                             model=iris_model,
-                             experiment_name='testingq',
-                             val_split=0.3,
-                             random_method='uniform_mersenne',
-                             round_limit=15,
-                             reduction_method='spearman',
-                             reduction_interval=10,
-                             reduction_window=9,
-                             reduction_threshold=0.01,
-                             reduction_metric='val_acc',
-                             minimize_loss=False,
-                             boolean_limit=lambda p: p['first_neuron'] * p['hidden_layers'] < 220
-                             )
+
+    if not test_sample_weights:
+        scan_object = talos.Scan(x=x,
+                                 y=y,
+                                 params=p,
+                                 model=iris_model,
+                                 experiment_name='testingq',
+                                 val_split=0.3,
+                                 random_method='uniform_mersenne',
+                                 round_limit=15,
+                                 reduction_method='spearman',
+                                 reduction_interval=10,
+                                 reduction_window=9,
+                                 reduction_threshold=0.01,
+                                 reduction_metric='val_acc',
+                                 minimize_loss=False,
+                                 boolean_limit=lambda p: p['first_neuron'] * p['hidden_layers'] < 220
+        )
+    else:
+        scan_object = talos.Scan(x=x,
+                                 y=y,
+                                 sample_weight=rand(x.shape[0]),
+                                 params=p,
+                                 model=iris_model,
+                                 experiment_name='testingq_with_sample_weight',
+                                 val_split=0.3,
+                                 random_method='uniform_mersenne',
+                                 round_limit=15,
+                                 reduction_method='spearman',
+                                 reduction_interval=10,
+                                 reduction_window=9,
+                                 reduction_threshold=0.01,
+                                 reduction_metric='val_acc',
+                                 minimize_loss=False,
+                                 boolean_limit=lambda p: p['first_neuron'] * p['hidden_layers'] < 220
+        )
 
     x = x[:50]
     y = y[:50]

--- a/test_script.py
+++ b/test_script.py
@@ -12,6 +12,9 @@ if __name__ == '__main__':
     scan_object = test_scan()
     test_analyze(scan_object)
 
+    scan_object_with_weights = test_scan(test_sample_weights=True)
+    test_analyze(scan_object_with_weights)
+
     test_lr_normalizer()
     test_predict()
     test_reducers()


### PR DESCRIPTION
Hi,

I have added a `sample_weight` arugment to `Scan()`. I realise that it was possible to use the `sample_weight` argument of the Keras model fit method if one were to pass `x_val` and `y_val`, however this would require defining the weights outside of the model function which I don't find very satisfying. 

The weights have been added as an argument to `Scan()` as opposed to an element of `params` as I do not consider the sample weights to be a hyper-parameter and it would seem to conflict with your design philosophy especially regarding the automated parameters (you can't automatically generate sample weights for example). 

This change has resulted in the signature of `model` which is being passed to `Scan()` being dependent on the arguments passed to `Scan()`. I appreciate that this adds some complexity but if the user does not touch the new argument the original behaviour should be preserved. This has been explained in the documentation.

Let me know what you think of this featue (it is essential for my work!). Maybe you can think of a more elegant implementation?

Thanks,
Tom

#### Sanity

- [x] I'm aware of the implications of the proposed changes
- [x] Code is [PEP8](https://www.python.org/dev/peps/pep-0008/)
- [x] I'm making the PR to `master`

#### Docs
I've made changes to the docs but assume the following are not satisfied automatically.

- [ ] [Docs](https://autonomio.github.io/talos) are updated
- [ ] [Docs](https://autonomio.github.io/talos) version is correct (index.html and \_coverpage.md)

#### Tests
I am on a windows machine and the `test_local.sh` script doesn't seem to work for me, so I just ran some examples on my own dataset that seemed to work just fine.
- [x] Changes have gone through actual use testing
- [ ] All local tests have passed (run ./test.sh in /talos)
- [x] Tests have been updated to reflect the changes

<hr>
